### PR TITLE
fix(metrics): avoid ZeroDivisionError in SummarizationScore on empty answers

### DIFF
--- a/src/ragas/metrics/_summarization.py
+++ b/src/ragas/metrics/_summarization.py
@@ -193,6 +193,8 @@ class SummarizationScore(MetricWithLLM, SingleTurnMetric):
         )
 
     def _compute_qa_score(self, answers: t.List[str]) -> float:
+        if not answers:
+            return 0.0
         correct = sum([1 for a in answers if a.lower() == "1"])
         return correct / len(answers)
 

--- a/src/ragas/metrics/collections/summary_score/metric.py
+++ b/src/ragas/metrics/collections/summary_score/metric.py
@@ -185,11 +185,11 @@ class SummaryScore(BaseMetric):
         return result.answers
 
     def _compute_qa_score(self, answers: List[str]) -> float:
-        """Compute QA score as ratio of correct answers. Matches legacy behavior exactly."""
+        """Compute QA score as ratio of correct answers."""
+        if not answers:
+            return 0.0
         correct = sum([1 for a in answers if a.lower() == "1"])
-        return correct / len(
-            answers
-        )  # Will raise ZeroDivisionError if answers is empty (legacy behavior)
+        return correct / len(answers)
 
     def _compute_conciseness_score(self, text: str, summary: str) -> float:
         """Compute conciseness score based on length ratio."""


### PR DESCRIPTION
Fixes #2905

## Summary
`SummarizationScore._compute_qa_score` crashed with `ZeroDivisionError` when the LLM returned no answers. Return `0.0` for the empty case in both legacy and collections implementations.

## Test plan
- [ ] `_compute_qa_score([])` returns `0.0`
- [ ] non-empty answers unchanged