### PR TITLE
fix(metrics): tag multi-turn analytics as MULTI_TURN

### DIFF
--- a/src/ragas/metrics/base.py
+++ b/src/ragas/metrics/base.py
@@ -575,7 +575,7 @@ class MultiTurnMetric(Metric):
             EvaluationEvent(
                 metrics=[self.name],
                 num_rows=1,
-                evaluation_type=MetricType.SINGLE_TURN.name,
+                evaluation_type=MetricType.MULTI_TURN.name,
                 language=get_metric_language(self),
             )
         )
@@ -619,7 +619,7 @@ class MultiTurnMetric(Metric):
             EvaluationEvent(
                 metrics=[self.name],
                 num_rows=1,
-                evaluation_type=MetricType.SINGLE_TURN.name,
+                evaluation_type=MetricType.MULTI_TURN.name,
                 language=get_metric_language(self),
             )
         )


### PR DESCRIPTION
Fixes #2910

## Summary
`MultiTurnMetric.multi_turn_score` / `multi_turn_ascore` were emitting `evaluation_type=SINGLE_TURN` due to a copy-paste. Use `MetricType.MULTI_TURN.name` instead.

## Test plan
- [ ] Analytics events from multi-turn scoring report MULTI_TURN