### PR TITLE
fix(prompt): InMemoryExampleStore returns [] for top_k<=0

### DIFF
--- a/src/ragas/prompt/few_shot_pydantic_prompt.py
+++ b/src/ragas/prompt/few_shot_pydantic_prompt.py
@@ -80,6 +80,11 @@ class InMemoryExampleStore(ExampleStore):
         # Get indices of similarities above threshold
         valid_indices = np.where(similarities >= threshold)[0]
 
+        # Non-positive top_k must return nothing. Note: [-0:] is [0:] in Python/numpy
+        # (same class of bug as SimpleInMemoryExampleStore / #2872).
+        if top_k <= 0 or len(valid_indices) == 0:
+            return []
+
         # Sort by similarity and get top-k
         top_indices = valid_indices[np.argsort(similarities[valid_indices])[-top_k:]]
 


### PR DESCRIPTION
Fixes #2877

## Summary
`top_k=0` used `[-top_k:]` which becomes `[-0:]` / full array. Return an empty list for non-positive `top_k` (same class of bug as #2872).

## Test plan
- [ ] `get_nearest_examples(..., top_k=0)` returns `[]`