### PR TITLE
fix(optimizers): inspect_history(n=0) returns empty list

### DIFF
--- a/src/ragas/optimizers/dspy_llm_wrapper.py
+++ b/src/ragas/optimizers/dspy_llm_wrapper.py
@@ -100,4 +100,8 @@ class RagasDSPyLM:
         List[Dict[str, Any]]
             Recent call history.
         """
+        # Python evaluates -0 as 0, so history[-0:] is the full list. Treat
+        # non-positive n as "return nothing" (same class of bug as #2872/#2877).
+        if n <= 0:
+            return []
         return self.history[-n:]


### PR DESCRIPTION
Fixes #2885

## Summary
`history[-0:]` returns the full history. Guard non-positive `n` and return `[]`.

## Test plan
- [ ] `inspect_history(0)` is empty; positive n unchanged