### PR TITLE
fix(metrics): ContextPrecision can return exactly 1.0

### DIFF
--- a/docs/concepts/metrics/available_metrics/context_precision.md
+++ b/docs/concepts/metrics/available_metrics/context_precision.md
@@ -46,7 +46,7 @@ print(f"Context Precision Score: {result.value}")
 
 Output:
 ```
-Context Precision Score: 0.9999999999
+Context Precision Score: 1.0
 ```
 
 !!! note "Synchronous Usage"
@@ -90,7 +90,7 @@ print(f"Context Utilization Score: {result.value}")
 
 Output:
 ```
-Context Utilization Score: 0.9999999999
+Context Utilization Score: 1.0
 ```
 
 Note that even if an irrelevant chunk is present at the second position in the array, context precision remains the same. However, if this irrelevant chunk is placed at the first position, context precision reduces:
@@ -138,12 +138,12 @@ await context_precision.single_turn_ascore(sample)
 
 Output:
 ```
-0.9999999999
+1.0
 ```
 
 ### Context Precision without reference
 
-The `LLMContextPrecisionWithoutReference` metric can be used without the availability of a reference answer. To estimate if the retrieved contexts are relevant, this method uses the LLM to compare each chunk in `retrieved_contexts` with the `response`.
+The `LLMContextPrecisionWithoutReference` metric can be used when you have `user_input`, `response`, and `retrieved_contexts` — **without** a reference answer or reference contexts. To estimate whether each retrieved chunk is relevant, the LLM compares the chunk against the generated `response` (not against gold contexts).
 
 #### Example
 
@@ -164,7 +164,7 @@ await context_precision.single_turn_ascore(sample)
 
 Output:
 ```
-0.9999999999
+1.0
 ```
 
 ### Context Precision with reference
@@ -190,7 +190,7 @@ await context_precision.single_turn_ascore(sample)
 
 Output:
 ```
-0.9999999999
+1.0
 ```
 
 ## Non LLM Based Context Precision
@@ -221,7 +221,7 @@ await context_precision.single_turn_ascore(sample)
 
 Output:
 ```
-0.9999999999
+1.0
 ```
 
 ## ID Based Context Precision

--- a/src/ragas/metrics/_context_precision.py
+++ b/src/ragas/metrics/_context_precision.py
@@ -123,8 +123,9 @@ class LLMContextPrecisionWithReference(MetricWithLLM, SingleTurnMetric):
             if v:
                 numerator += cumsum / (i + 1)
 
-        denominator = cumsum + 1e-10
-        score = numerator / denominator
+        # Guard zero-relevant only; unconditional 1e-10 made perfect rankings
+        # score 0.9999999999 instead of 1.0.
+        score = numerator / cumsum if cumsum else 0.0
         if np.isnan(score):
             logger.warning(
                 "Invalid response format. Expected a list of dictionaries with keys 'verdict'"
@@ -242,9 +243,8 @@ class NonLLMContextPrecisionWithReference(SingleTurnMetric):
             if v:
                 numerator += cumsum / (i + 1)
 
-        denominator = cumsum + 1e-10
-        score = numerator / denominator
-        return score
+        # Guard zero-relevant only so a perfect ranking can score exactly 1.0.
+        return numerator / cumsum if cumsum else 0.0
 
 
 @dataclass

--- a/src/ragas/metrics/collections/context_precision/metric.py
+++ b/src/ragas/metrics/collections/context_precision/metric.py
@@ -124,8 +124,9 @@ class ContextPrecisionWithReference(BaseMetric):
             if v:
                 numerator += cumsum / (i + 1)
 
-        denominator = cumsum + 1e-10
-        score = numerator / denominator
+        # Guard zero-relevant only; unconditional 1e-10 made perfect rankings
+        # score 0.9999999999 instead of 1.0.
+        score = numerator / cumsum if cumsum else 0.0
 
         if np.isnan(score):
             # Match legacy warning behavior
@@ -244,8 +245,8 @@ class ContextPrecisionWithoutReference(BaseMetric):
             if v:
                 numerator += cumsum / (i + 1)
 
-        denominator = cumsum + 1e-10
-        score = numerator / denominator
+        # Guard zero-relevant only so a perfect ranking can score exactly 1.0.
+        score = numerator / cumsum if cumsum else 0.0
 
         if np.isnan(score):
             # Match legacy warning behavior


### PR DESCRIPTION
Fixes #2909
Also clarifies docs for without-reference precision (#1981) and updates example scores that showed 0.9999999999.

## Summary
Average precision used `cumsum + 1e-10` in the denominator unconditionally, so perfect rankings never scored exactly 1.0. Only guard the zero-relevant case. Applied in legacy + collections implementations; docs examples updated.

## Test plan
- [ ] Perfect ranking yields 1.0
- [ ] Empty/all-irrelevant yields 0.0