### PR TITLE
fix(metrics): do not format None into InstanceRubrics prompt

### DIFF
--- a/src/ragas/metrics/_instance_specific_rubrics.py
+++ b/src/ragas/metrics/_instance_specific_rubrics.py
@@ -97,7 +97,8 @@ class InstanceRubrics(MetricWithLLM, SingleTurnMetric, MultiTurnMetric):
         )
         if contexts is not None:
             contexts = "\n".join(contexts)
-            user_input = f"{user_input} answer using context: {contexts}"
+            # user_input is Optional[str]; f"{None}" becomes the literal "None".
+            user_input = f"{user_input or ''} answer using context: {contexts}"
 
         if rubrics is None:
             raise ValueError(f"Rubrics are not set for the sample: {row}")


### PR DESCRIPTION
Fixes #2901

## Summary
When `user_input` is `None` but contexts are present, the f-string produced the literal `"None answer using context: ..."`. Use `user_input or ''`.

## Test plan
- [ ] Prompt no longer contains the word None as user input