### PR TITLE
fix(dataset): train_test_split reloads empty tables via reload()

### DIFF
--- a/src/ragas/dataset.py
+++ b/src/ragas/dataset.py
@@ -392,7 +392,9 @@ class DataTable(t.Generic[T]):
             A tuple of two Datasets: (train_dataset, test_dataset)
         """
         if not self._data:
-            self.load(self.name, self.backend, self.data_model)
+            # load() is a classmethod that returns a new instance; reload()
+            # rehydrates this instance in place from the backend.
+            self.reload()
 
         # Shuffle entries if random_state is set
         if random_state is not None:


### PR DESCRIPTION
Fixes #2896

## Summary
`train_test_split` called `self.load(...)` which is a classmethod returning a new instance (discarded), so empty `_data` stayed empty. Use in-place `self.reload()`.

## Test plan
- [ ] Dataset loaded from backend without data= splits non-empty after save