### PR TITLE
fix(metrics): BleuScore evaluates full text, not only first sentence

### DIFF
--- a/src/ragas/metrics/_bleu_score.py
+++ b/src/ragas/metrics/_bleu_score.py
@@ -35,12 +35,10 @@ class BleuScore(SingleTurnMetric):
         assert isinstance(reference, str), "BleuScore expects a valid reference string"
         assert isinstance(response, str), "BleuScore expects a valid response string"
 
-        reference_sentences = reference.split(". ")
-        response_sentences = response.split(". ")
-
-        reference = [[reference] for reference in reference_sentences]
-        response = response_sentences
-        score = self.corpus_bleu(response, reference, **self.kwargs).score / 100
+        # Pass full texts as a single segment. Splitting into sentences and
+        # building N reference streams of length 1 made sacrebleu's zip truncate
+        # after the first sentence (only the first sentence was scored).
+        score = self.corpus_bleu([response], [[reference]], **self.kwargs).score / 100
         assert isinstance(score, float), "Expecting a float"
         return score
 

--- a/src/ragas/metrics/collections/_bleu_score.py
+++ b/src/ragas/metrics/collections/_bleu_score.py
@@ -71,16 +71,9 @@ class BleuScore(BaseMetric):
         assert isinstance(reference, str), "BleuScore expects a valid reference string"
         assert isinstance(response, str), "BleuScore expects a valid response string"
 
-        reference_sentences = reference.split(". ")
-        response_sentences = response.split(". ")
-
-        reference_formatted = [[ref] for ref in reference_sentences]
-        response_formatted = response_sentences
-
-        score = (
-            corpus_bleu(response_formatted, reference_formatted, **self.kwargs).score
-            / 100
-        )
+        # Pass full texts as a single segment (matches ChrfScore). Sentence-splitting
+        # into N streams of length 1 made sacrebleu only score the first sentence.
+        score = corpus_bleu([response], [[reference]], **self.kwargs).score / 100
 
         assert isinstance(score, float), "Expecting a float"
         return MetricResult(value=float(score))


### PR DESCRIPTION
Fixes #2888

Sentence-splitting caused sacrebleu to score only the first sentence. Pass full texts as a single segment (legacy + collections).