### PR TITLE
fix(backends): LocalCSVBackend saves rows with heterogeneous keys

### DIFF
--- a/src/ragas/backends/local_csv.py
+++ b/src/ragas/backends/local_csv.py
@@ -86,10 +86,18 @@ class LocalCSVBackend(BaseBackend):
                 pass
             return
 
-        # Write data to CSV
+        # Write data to CSV. Union keys across all rows so optional fields on
+        # later rows (e.g. reason/error on experiment results) do not crash
+        # DictWriter (extrasaction="raise" by default).
         with open(file_path, "w", newline="", encoding="utf-8") as f:
-            fieldnames = data[0].keys()
-            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            fieldnames: list[str] = []
+            seen: set[str] = set()
+            for row in data:
+                for key in row.keys():
+                    if key not in seen:
+                        seen.add(key)
+                        fieldnames.append(key)
+            writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
             writer.writeheader()
             writer.writerows(data)
 


### PR DESCRIPTION
Fixes #2860

## Summary
`LocalCSVBackend._save` took CSV headers only from the first row, so later rows with extra keys (e.g. optional `reason`/`error`) raised `ValueError` under `DictWriter`. Build the header as the union of keys across all rows.

## Test plan
- [ ] Saving mixed-key experiment rows succeeds
- [ ] Empty data still creates empty file