### PR TITLE
fix(metrics): keep caller kwargs when @metric pydantic model creation fails

### DIFF
--- a/src/ragas/metrics/decorator.py
+++ b/src/ragas/metrics/decorator.py
@@ -220,10 +220,12 @@ def create_metric_decorator():
                     try:
                         pydantic_model = self._create_pydantic_model()
                     except Exception as e:
-                        # Fallback if model creation fails
+                        # Fallback if model creation fails: still pass caller kwargs
+                        # through so the metric function is not invoked as func(**{}).
                         warnings.warn(
                             f"Could not create validation model: {e}", UserWarning
                         )
+                        self._validated_data = dict(kwargs)
                         return
 
                     # Warn about unknown arguments (but continue processing)


### PR DESCRIPTION
Fixes #2903

## Summary
When `_create_pydantic_model` failed, `_validate_inputs` returned without setting `_validated_data`, so `ascore` called `func(**{})` and dropped caller kwargs. Store `dict(kwargs)` on that fallback path.

## Test plan
- [ ] Metric still receives kwargs if model creation fails
- [ ] Normal validation path unchanged