### PR TITLE
fix(integrations): Swarm converter handles assistant messages without tool_calls

### DIFF
--- a/src/ragas/integrations/swarm.py
+++ b/src/ragas/integrations/swarm.py
@@ -43,9 +43,8 @@ def convert_to_ragas_messages(
 
     def handle_assistant_message(message: Dict[str, Any]) -> AIMessage:
         """Convert assistant message to Ragas AIMessage"""
-        tool_calls = (
-            convert_tool_calls(message["tool_calls"]) if message["tool_calls"] else []
-        )
+        raw_tool_calls = message.get("tool_calls") or []
+        tool_calls = convert_tool_calls(raw_tool_calls) if raw_tool_calls else []
         ai_message_content = message.get("content")
         return AIMessage(
             content=ai_message_content if ai_message_content else "",


### PR DESCRIPTION
Fixes #2813

## Summary
`handle_assistant_message` indexed `message["tool_calls"]` and raised `KeyError` for plain assistant turns. Use `.get("tool_calls")` and default to an empty tool-call list.

## Test plan
- [ ] `convert_to_ragas_messages([{role: assistant, content: hi}])` works
- [ ] Messages with tool_calls still convert