### PR TITLE
fix(integrations): forward async callbacks in EvaluatorChain._acall

### DIFF
--- a/src/ragas/integrations/langchain.py
+++ b/src/ragas/integrations/langchain.py
@@ -115,14 +115,15 @@ class EvaluatorChain(Chain, RunEvaluator):
 
         self._validate(inputs)
         _run_manager = run_manager or AsyncCallbackManagerForChainRun.get_noop_manager()
-        # TODO: currently AsyncCallbacks are not supported in ragas
-        _run_manager.get_child()
+        # Mirror the sync path: forward the child callback manager so async
+        # LangChain/LangSmith handlers observe metric-internal LLM calls.
+        callbacks = _run_manager.get_child()
         assert isinstance(self.metric, SingleTurnMetric), (
             "Metric must be SingleTurnMetric"
         )
         score = await self.metric.single_turn_ascore(
             inputs,
-            callbacks=[],
+            callbacks=callbacks,
         )
         return {self.metric.name: score}
 


### PR DESCRIPTION
Fixes #2883

## Summary
Sync `_call` already forwards `_run_manager.get_child()` callbacks; `_acall` discarded them and passed `callbacks=[]`. Mirror the sync path so async LangChain/LangSmith handlers see metric-internal LLM calls.

## Test plan
- [ ] Async chain callbacks receive metric child events
- [ ] Sync path unchanged