### PR TITLE
fix: strip deprecated top_p for Anthropic provider in InstructorLLM

### DIFF
--- a/src/ragas/llms/base.py
+++ b/src/ragas/llms/base.py
@@ -826,7 +826,7 @@ class InstructorLLM(InstructorBaseRagasLLM):
         Each provider may have different parameter requirements:
         - Google: Wraps parameters in generation_config and renames max_tokens
         - OpenAI/Azure: Maps max_tokens to max_completion_tokens for o-series models
-        - Anthropic: No special handling required (pass-through)
+        - Anthropic: Removes deprecated top_p (rejected with 400 on current-gen models)
         - LiteLLM: No special handling required (routes internally, pass-through)
         """
         provider_lower = self.provider.lower()
@@ -835,9 +835,24 @@ class InstructorLLM(InstructorBaseRagasLLM):
             return self._map_google_params()
         elif provider_lower in ("openai", "azure"):
             return self._map_openai_params()
+        elif provider_lower == "anthropic":
+            return self._map_anthropic_params()
         else:
-            # Anthropic, LiteLLM, and other providers - pass through unchanged
+            # LiteLLM and other providers - pass through unchanged
             return self.model_args.copy()
+
+    def _map_anthropic_params(self) -> t.Dict[str, t.Any]:
+        """Map parameters for Anthropic models.
+
+        top_p is deprecated for models released after Claude Opus 4.6: values
+        below 0.99 are rejected with a 400 error, and temperature/top_p cannot
+        both be specified. Since InstructorModelArgs defaults top_p=0.1 and
+        temperature is always present, top_p is stripped to avoid the 400.
+        See: https://platform.claude.com/docs/en/api/python/messages/create
+        """
+        mapped_args = self.model_args.copy()
+        mapped_args.pop("top_p", None)
+        return mapped_args
 
     def _map_openai_params(self) -> t.Dict[str, t.Any]:
         """Map parameters for OpenAI/Azure reasoning models with special constraints.

--- a/tests/unit/llms/test_provider_params.py
+++ b/tests/unit/llms/test_provider_params.py
@@ -1,0 +1,128 @@
+"""Tests for InstructorLLM provider-specific parameter mapping.
+
+Covers the Anthropic top_p deprecation fix (#2674) and regression coverage
+for the existing Google and OpenAI/Azure mapping branches.
+"""
+
+from unittest.mock import Mock
+
+from ragas.llms.base import InstructorLLM
+
+
+def _make_llm(provider: str, model: str = "test-model", **kwargs) -> InstructorLLM:
+    """Build an InstructorLLM with a minimal mock client for param-mapping tests."""
+    client = Mock()
+    client.chat = Mock()
+    client.chat.completions = Mock()
+    client.chat.completions.create = Mock()
+    return InstructorLLM(client=client, model=model, provider=provider, **kwargs)
+
+
+class TestAnthropicParamMapping:
+    """Regression tests for issue #2674: deprecated top_p sent to Anthropic."""
+
+    def test_default_top_p_is_stripped(self):
+        """Default top_p=0.1 must not be forwarded to Anthropic (would 400)."""
+        llm = _make_llm("anthropic", model="claude-sonnet-4-6")
+
+        mapped = llm._map_provider_params()
+
+        assert "top_p" not in mapped
+        assert mapped["temperature"] == 0.01
+        assert mapped["max_tokens"] == 1024
+
+    def test_explicit_top_p_is_stripped(self):
+        """Even an explicit top_p is stripped because temperature is always
+        present and Anthropic rejects sending both on current-gen models."""
+        llm = _make_llm("anthropic", model="claude-sonnet-4-6", top_p=0.5)
+
+        mapped = llm._map_provider_params()
+
+        assert "top_p" not in mapped
+
+    def test_other_params_preserved(self):
+        """temperature and max_tokens must survive the Anthropic mapping."""
+        llm = _make_llm(
+            "anthropic",
+            model="claude-sonnet-4-6",
+            temperature=0.0,
+            max_tokens=2048,
+        )
+
+        mapped = llm._map_provider_params()
+
+        assert mapped["temperature"] == 0.0
+        assert mapped["max_tokens"] == 2048
+        assert "top_p" not in mapped
+
+    def test_anthropic_branch_invoked(self):
+        """provider='anthropic' must route to _map_anthropic_params, not pass-through."""
+        llm = _make_llm("anthropic", model="claude-sonnet-4-6")
+
+        mapped = llm._map_provider_params()
+
+        # If pass-through had been used, top_p=0.1 would still be present.
+        assert "top_p" not in mapped
+
+    def test_anthropic_case_insensitive(self):
+        """Provider matching should be case-insensitive (uses .lower())."""
+        llm = _make_llm("Anthropic", model="claude-sonnet-4-6")
+
+        mapped = llm._map_provider_params()
+
+        assert "top_p" not in mapped
+
+    def test_does_not_mutate_model_args(self):
+        """_map_provider_params must not mutate self.model_args (returns a copy)."""
+        llm = _make_llm("anthropic", model="claude-sonnet-4-6")
+        original = llm.model_args.copy()
+
+        _ = llm._map_provider_params()
+
+        assert llm.model_args == original
+        assert "top_p" in llm.model_args  # still present on the instance
+
+
+class TestNonAnthropicRegression:
+    """Ensure the Anthropic branch does not affect other providers."""
+
+    def test_google_still_wraps_generation_config(self):
+        llm = _make_llm("google", model="gemini-2.0-flash")
+
+        mapped = llm._map_provider_params()
+
+        # Google wraps temperature/max_tokens/top_p inside generation_config.
+        assert "generation_config" in mapped
+        gc = mapped["generation_config"]
+        assert gc["temperature"] == 0.01
+        assert gc["max_output_tokens"] == 1024
+        assert gc["top_p"] == 0.1
+
+    def test_openai_legacy_passes_top_p(self):
+        """Legacy OpenAI models (gpt-4) should still receive top_p unchanged."""
+        llm = _make_llm("openai", model="gpt-4o")
+
+        mapped = llm._map_provider_params()
+
+        # gpt-4o is not a reasoning model, so top_p is preserved.
+        assert mapped["top_p"] == 0.1
+        assert mapped["max_tokens"] == 1024
+
+    def test_openai_reasoning_strips_top_p(self):
+        """Reasoning models (o-series, gpt-5+) strip top_p via _map_openai_params."""
+        llm = _make_llm("openai", model="o3-mini")
+
+        mapped = llm._map_provider_params()
+
+        assert "top_p" not in mapped
+        assert mapped["temperature"] == 1.0
+        assert mapped["max_completion_tokens"] == 1024
+
+    def test_litellm_passes_through(self):
+        """LiteLLM is the fallback pass-through; top_p must remain."""
+        llm = _make_llm("litellm", model="gpt-4o")
+
+        mapped = llm._map_provider_params()
+
+        assert mapped["top_p"] == 0.1
+        assert mapped["temperature"] == 0.01


### PR DESCRIPTION
## Summary

Fixes #2674

`InstructorModelArgs` defaults `top_p=0.1`, which is always serialized via `model_dump()` and forwarded to the Anthropic API. Anthropic has deprecated `top_p` for models released after Claude Opus 4.6:

- Values below `0.99` are rejected with HTTP 400
- `temperature` and `top_p` cannot both be specified

Since `temperature` is always present (default `0.01`), any `top_p` value causes a 400 on current-gen Anthropic models, breaking all Ragas evaluations out of the box.

### Fix

Add an Anthropic-specific branch to `_map_provider_params` that strips `top_p`, following the existing Google and OpenAI/Azure mapping pattern. LiteLLM and other providers remain pass-through.

```python
elif provider_lower == "anthropic":
    return self._map_anthropic_params()
```

```python
def _map_anthropic_params(self) -> t.Dict[str, t.Any]:
    mapped_args = self.model_args.copy()
    mapped_args.pop("top_p", None)
    return mapped_args
```

### Why not make `top_p` optional on `InstructorModelArgs`?

Making `top_p` optional would be a breaking change for users who rely on the default for non-Anthropic providers (Google, OpenAI legacy models). A provider-specific mapping branch is consistent with the existing pattern (`_map_google_params`, `_map_openai_params`) and is the approach suggested by the issue reporter.

#### Test plan

- [x] 10 unit tests in `tests/unit/llms/test_provider_params.py` — all pass
  - [x] Default `top_p=0.1` is stripped for Anthropic
  - [x] Explicit `top_p` is stripped for Anthropic
  - [x] `temperature` and `max_tokens` are preserved for Anthropic
  - [x] Anthropic branch is actually invoked (not pass-through)
  - [x] Provider matching is case-insensitive
  - [x] `self.model_args` is not mutated (returns a copy)
  - [x] Google still wraps params in `generation_config` (regression)
  - [x] OpenAI legacy (gpt-4o) still receives `top_p` (regression)
  - [x] OpenAI reasoning (o3-mini) strips `top_p` via `_map_openai_params` (regression)
  - [x] LiteLLM pass-through preserves `top_p` (regression)
- [x] All 66 existing `tests/unit/llms/` tests still pass
- [x] `ruff format` clean
- [x] `ruff check` clean
- [x] `pyright` clean (0 errors, 0 warnings)