### PR TITLE
fix(ci): allow fork PR checkout in claude-docs-check workflow

### DIFF
--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -23,6 +23,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          # Required to check out fork PR code in a pull_request_target workflow.
+          # Safe here: the workflow only performs read-only doc analysis (no build,
+          # no test execution, no artifact upload) and permissions are scoped to
+          # contents: read / pull-requests: write. See:
+          # https://gh.io/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
 
       - name: Analyze PR for documentation needs
         id: analyze


### PR DESCRIPTION
## Summary

Fixes the `check-docs` CI failure that blocks **all fork-based PRs** from passing CI.

### Problem

The `claude-docs-check.yml` workflow uses `pull_request_target` (runs with the base repo's `GITHUB_TOKEN` and secrets) and checks out fork PR code via `actions/checkout@v4`. GitHub now refuses this by default to prevent "pwn request" attacks, failing with:

```
Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow.
This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache
scope, and runner access. Fetching and executing a fork's code in that trusted context
commonly leads to "pwn request" vulnerabilities.
```

This blocks every external contribution. Example: PR #2954 (a one-line fix for #2674) fails only on this check — the Read the Docs build passes, the code is clean, but `check-docs` can't even check out the code.

### Fix

Add `allow-unsafe-pr-checkout: true` to the `actions/checkout@v4` step (one line + explanatory comment).

### Security analysis — why this is safe

This workflow is safe to opt in because it does **not** execute untrusted PR code in the trusted context:

1. **No build/test execution** — the workflow only runs `actions/checkout` and `anthropics/claude-code-action@v1`. There is no `run:` step, no `npm install`, no `make`, no script evaluation of PR content.
2. **Read-only analysis** — the `claude-code-action` step's tools are restricted to `gh pr diff`, `gh pr view`, `Read`, `Glob`, `Grep` (per the security review in #2606).
3. **Scoped permissions** — `contents: read`, `pull-requests: write`, `issues: write`, `id-token: write`. No `contents: write`, so the token cannot modify the repo.
4. **Fork authors already permitted** — `allowed_non_write_users: "*"` was added in #2606, so the action already accepts fork PR authors. The checkout step was just never updated to match.

### Relationship to existing PRs

This is a **continuation** of the fork-contributor enablement work started in #2606, which fixed a different step in the same workflow (the `claude-code-action` permissions, not the `checkout` step).

There are 3 other open PRs touching this file (#2678, #2726, #2744), but they all address **shell injection in LLM output** — a different section of the workflow (the comment-posting step). This PR only touches the checkout step and does not conflict with them.

#### Test plan

- [ ] Verify `check-docs` CI passes on fork PRs after this is merged (re-run on #2954)
- [ ] Confirm no new security warnings from GitHub's security analysis
- [ ] Confirm the 3 shell-injection PRs (#2678, #2726, #2744) can still merge without conflict