### PR TITLE
fix(metrics): ContextPrecision returns exactly 1.0 for perfect ranking

### DIFF
--- a/src/ragas/metrics/_context_precision.py
+++ b/src/ragas/metrics/_context_precision.py
@@ -113,8 +113,6 @@ class LLMContextPrecisionWithReference(MetricWithLLM, SingleTurnMetric):
     def _calculate_average_precision(
         self, verifications: t.List[Verification]
     ) -> float:
-        score = np.nan
-
         cumsum = 0
         numerator = 0.0
         for i, ver in enumerate(verifications):
@@ -123,12 +121,7 @@ class LLMContextPrecisionWithReference(MetricWithLLM, SingleTurnMetric):
             if v:
                 numerator += cumsum / (i + 1)
 
-        denominator = cumsum + 1e-10
-        score = numerator / denominator
-        if np.isnan(score):
-            logger.warning(
-                "Invalid response format. Expected a list of dictionaries with keys 'verdict'"
-            )
+        score = numerator / cumsum if cumsum else 0.0
         return score
 
     async def _single_turn_ascore(
@@ -242,8 +235,7 @@ class NonLLMContextPrecisionWithReference(SingleTurnMetric):
             if v:
                 numerator += cumsum / (i + 1)
 
-        denominator = cumsum + 1e-10
-        score = numerator / denominator
+        score = numerator / cumsum if cumsum else 0.0
         return score
 
 

--- a/tests/unit/test_average_precision_algorithm.py
+++ b/tests/unit/test_average_precision_algorithm.py
@@ -19,8 +19,8 @@ def calculate_average_precision_original(verdict_list: List[int]) -> float:
             for i in range(len(verdict_list))
         ]
     )
-    denominator = sum(verdict_list) + 1e-10
-    return numerator / denominator
+    denominator = sum(verdict_list)
+    return numerator / denominator if denominator else 0.0
 
 
 def calculate_average_precision_optimized(verdict_list: List[int]) -> float:
@@ -32,8 +32,7 @@ def calculate_average_precision_optimized(verdict_list: List[int]) -> float:
         if v:
             numerator += cumsum / (i + 1)
 
-    denominator = cumsum + 1e-10
-    return numerator / denominator
+    return numerator / cumsum if cumsum else 0.0
 
 
 class TestAveragePrecisionAlgorithm:
@@ -86,3 +85,101 @@ class TestAveragePrecisionAlgorithm:
             original = calculate_average_precision_original(verdict_list)
             optimized = calculate_average_precision_optimized(verdict_list)
             assert np.isclose(original, optimized, rtol=1e-10, atol=1e-10)
+
+    # --- Exact-equality regression tests (issue #2909) ---
+
+    def test_perfect_ranking_returns_exactly_1(self):
+        """A perfectly ranked retrieval must return exactly 1.0, not 0.9999999999."""
+        assert calculate_average_precision_optimized([1]) == 1.0
+        assert calculate_average_precision_optimized([1, 1, 1]) == 1.0
+        assert calculate_average_precision_optimized([1] * 20) == 1.0
+
+    def test_no_relevant_returns_exactly_0(self):
+        """No relevant items must return exactly 0.0."""
+        assert calculate_average_precision_optimized([0]) == 0.0
+        assert calculate_average_precision_optimized([0, 0, 0]) == 0.0
+
+    def test_empty_returns_exactly_0(self):
+        """Empty verdict list must return exactly 0.0."""
+        assert calculate_average_precision_optimized([]) == 0.0
+
+    def test_mixed_ranking_exact_values(self):
+        """Verify exact scores for known mixed rankings (using approx for float division)."""
+        assert calculate_average_precision_optimized([1, 0, 1]) == pytest.approx(5 / 6)
+        assert calculate_average_precision_optimized([0, 1, 1]) == pytest.approx(7 / 12)
+
+
+class TestMetricAveragePrecisionExact:
+    """Exact-equality tests calling the real metric classes (issue #2909)."""
+
+    def test_llm_context_precision_perfect_ranking(self):
+        """LLMContextPrecisionWithReference._calculate_average_precision returns exactly 1.0."""
+        from ragas.metrics._context_precision import (
+            LLMContextPrecisionWithReference,
+            Verification,
+        )
+
+        metric = LLMContextPrecisionWithReference()
+        verdicts = [Verification(reason="ok", verdict=1) for _ in range(5)]
+        assert metric._calculate_average_precision(verdicts) == 1.0
+
+    def test_llm_context_precision_no_relevant(self):
+        """LLMContextPrecisionWithReference._calculate_average_precision returns exactly 0.0."""
+        from ragas.metrics._context_precision import (
+            LLMContextPrecisionWithReference,
+            Verification,
+        )
+
+        metric = LLMContextPrecisionWithReference()
+        verdicts = [Verification(reason="no", verdict=0) for _ in range(3)]
+        assert metric._calculate_average_precision(verdicts) == 0.0
+
+    def test_llm_context_precision_empty(self):
+        """LLMContextPrecisionWithReference._calculate_average_precision on empty returns 0.0."""
+        from ragas.metrics._context_precision import LLMContextPrecisionWithReference
+
+        metric = LLMContextPrecisionWithReference()
+        assert metric._calculate_average_precision([]) == 0.0
+
+    def test_llm_context_precision_mixed(self):
+        """LLMContextPrecisionWithReference._calculate_average_precision on [1,0,1] == 5/6."""
+        from ragas.metrics._context_precision import (
+            LLMContextPrecisionWithReference,
+            Verification,
+        )
+
+        metric = LLMContextPrecisionWithReference()
+        verdicts = [
+            Verification(reason="yes", verdict=1),
+            Verification(reason="no", verdict=0),
+            Verification(reason="yes", verdict=1),
+        ]
+        assert metric._calculate_average_precision(verdicts) == pytest.approx(5 / 6)
+
+    def test_non_llm_context_precision_perfect_ranking(self):
+        """NonLLMContextPrecisionWithReference._calculate_average_precision returns exactly 1.0."""
+        from ragas.metrics._context_precision import NonLLMContextPrecisionWithReference
+
+        metric = NonLLMContextPrecisionWithReference()
+        assert metric._calculate_average_precision([1, 1, 1]) == 1.0
+
+    def test_non_llm_context_precision_no_relevant(self):
+        """NonLLMContextPrecisionWithReference._calculate_average_precision returns exactly 0.0."""
+        from ragas.metrics._context_precision import NonLLMContextPrecisionWithReference
+
+        metric = NonLLMContextPrecisionWithReference()
+        assert metric._calculate_average_precision([0, 0, 0]) == 0.0
+
+    def test_non_llm_context_precision_empty(self):
+        """NonLLMContextPrecisionWithReference._calculate_average_precision on empty returns 0.0."""
+        from ragas.metrics._context_precision import NonLLMContextPrecisionWithReference
+
+        metric = NonLLMContextPrecisionWithReference()
+        assert metric._calculate_average_precision([]) == 0.0
+
+    def test_non_llm_context_precision_mixed(self):
+        """NonLLMContextPrecisionWithReference._calculate_average_precision on [0,1,1] == 7/12."""
+        from ragas.metrics._context_precision import NonLLMContextPrecisionWithReference
+
+        metric = NonLLMContextPrecisionWithReference()
+        assert metric._calculate_average_precision([0, 1, 1]) == pytest.approx(7 / 12)


### PR DESCRIPTION
## Summary

`ContextPrecision` could never return exactly `1.0`. A perfectly ranked retrieval scored `0.9999999999` because of an unconditional `1e-10` epsilon added to the denominator. This broke any threshold check or test asserting `score == 1.0` and made the metric disagree with standard average-precision implementations.

## Root cause

Both `_calculate_average_precision` methods in `_context_precision.py` added `1e-10` to the denominator unconditionally:

```python
denominator = cumsum + 1e-10
score = numerator / denominator
```

Since `cumsum` is an integer count of relevant items, the epsilon is only needed when `cumsum == 0` (to avoid division by zero). Adding it to every result scales all non-zero scores by `cumsum / (cumsum + 1e-10)`.

## Fix

Guard only the zero case, matching the standard average-precision definition:

```python
score = numerator / cumsum if cumsum else 0.0
```

Applied to both copies:
- `LLMContextPrecisionWithReference._calculate_average_precision` (takes `List[Verification]`)
- `NonLLMContextPrecisionWithReference._calculate_average_precision` (takes `List[int]`)

Also removed the unreachable `np.isnan(score)` warning branch in the LLM variant. With the epsilon always present, `score` could never be NaN. With the fix, `score` is `0.0` when `cumsum == 0` and a finite float otherwise, so the branch remains unreachable.

## Before / after

| verdicts | before | after |
|---|---|---|
| `[1, 1, 1]` | `0.9999999999666667` | `1.0` |
| `[1]` | `0.9999999999` | `1.0` |
| `[1, 0, 1]` | `0.8333333332916666` | `0.8333333333333333` |
| `[0, 1, 1]` | `0.5833333333041666` | `0.5833333333333333` |
| `[0, 0, 0]` | `0.0` | `0.0` |
| `[]` | `0.0` | `0.0` |

## Tests

Added exact-equality regression tests (`assert score == 1.0`, not `pytest.approx`) for both metric classes:
- Perfect ranking returns exactly `1.0`
- No relevant items returns exactly `0.0`
- Empty input returns exactly `0.0`
- Mixed rankings match expected rational values

Also updated the helper functions in `test_average_precision_algorithm.py` to match the fixed code (they previously mirrored the buggy `+ 1e-10` denominator).

All 27 tests in `test_average_precision_algorithm.py` pass. `ruff check` and `ruff format --check` clean.

Closes #2909